### PR TITLE
Fix coroutines error in Python 3.11

### DIFF
--- a/custom_components/miio_yeelink/__init__.py
+++ b/custom_components/miio_yeelink/__init__.py
@@ -207,7 +207,7 @@ def bind_services_to_entries(hass, services):
                 _LOGGER.info('%s have no method: %s', dvc.entity_id, fun)
                 continue
             await getattr(dvc, fun)(**params)
-            update_tasks.append(dvc.async_update_ha_state(True))
+            update_tasks.append(asyncio.create_task(dvc.async_update_ha_state(True)))
         if update_tasks:
             await asyncio.wait(update_tasks)
 


### PR DESCRIPTION
Since Home Assistant 2023.6 moved to Python 3.11, using coroutines is forbidden. This commit uses an explicit task to get rid of errors when using different services. This has been tested locally in Home Assistant 2023.6.1 and works flawlessly